### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,8 @@
 # documentation.
 
 name: Java CI with Maven
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/kothar-1992/Bear-Loader/security/code-scanning/1](https://github.com/kothar-1992/Bear-Loader/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow file. This should be placed at the root level (as a top-level key, beneath the `name:` declaration and above or below the `on:` trigger), unless certain jobs need custom scopes. For a minimal and secure approach, set `contents: read`, which is broadly sufficient for most CI scenarios that do not need to push code, create PRs, or modify issues. If a particular step later requires broader permissions, those can be added as exceptions. In this file, add:

```yaml
permissions:
  contents: read
```

just below the `name:` field. This will ensure all jobs default to read-only GITHUB_TOKEN access, limiting exposure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
